### PR TITLE
Feature/using content views

### DIFF
--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BD38451D288F274B005FD8EB /* ReminderDoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38451C288F274B005FD8EB /* ReminderDoneButton.swift */; };
 		BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38451E288F3EB6005FD8EB /* ReminderListViewController+Actions.swift */; };
 		BD56783E28B3ECD5002C1D55 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD56783D28B3ECD5002C1D55 /* ReminderViewController+Section.swift */; };
+		BD856AB628C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD856AB528C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift */; };
 		BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */; };
 		BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */; };
 		BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */; };
@@ -29,6 +30,7 @@
 		BD38451C288F274B005FD8EB /* ReminderDoneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderDoneButton.swift; sourceTree = "<group>"; };
 		BD38451E288F3EB6005FD8EB /* ReminderListViewController+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+Actions.swift"; sourceTree = "<group>"; };
 		BD56783D28B3ECD5002C1D55 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
+		BD856AB528C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+CellConfiguration.swift"; sourceTree = "<group>"; };
 		BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Today.swift"; sourceTree = "<group>"; };
 		BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+DataSource.swift"; sourceTree = "<group>"; };
 		BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Today.swift"; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 				BDF4120D28AAE9800030DB9E /* ReminderViewController.swift */,
 				BD0A784E28AEE0480040DFD7 /* ReminderViewController+Row.swift */,
 				BD56783D28B3ECD5002C1D55 /* ReminderViewController+Section.swift */,
+				BD856AB528C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift */,
 			);
 			path = DetailViewController;
 			sourceTree = "<group>";
@@ -198,6 +201,7 @@
 				BD0A784F28AEE0480040DFD7 /* ReminderViewController+Row.swift in Sources */,
 				BD38451D288F274B005FD8EB /* ReminderDoneButton.swift in Sources */,
 				BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */,
+				BD856AB628C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BDE2B5CE288C35020023F5EB /* SceneDelegate.swift in Sources */,
 				BDE2B5E1288C386B0023F5EB /* Reminder.swift in Sources */,
 				BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */,

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -12,9 +12,12 @@
 		BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38451E288F3EB6005FD8EB /* ReminderListViewController+Actions.swift */; };
 		BD56783E28B3ECD5002C1D55 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD56783D28B3ECD5002C1D55 /* ReminderViewController+Section.swift */; };
 		BD856AB628C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD856AB528C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift */; };
+		BD856AB928C3928D00052BB2 /* UIView+PinnedSubview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD856AB828C3928D00052BB2 /* UIView+PinnedSubview.swift */; };
+		BD856ABB28C3953B00052BB2 /* TextFieldContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD856ABA28C3953B00052BB2 /* TextFieldContentView.swift */; };
 		BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */; };
 		BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */; };
 		BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */; };
+		BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */; };
 		BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CB288C35020023F5EB /* AppDelegate.swift */; };
 		BDE2B5CE288C35020023F5EB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */; };
 		BDE2B5D0288C35020023F5EB /* ReminderListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CF288C35020023F5EB /* ReminderListViewController.swift */; };
@@ -31,9 +34,12 @@
 		BD38451E288F3EB6005FD8EB /* ReminderListViewController+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+Actions.swift"; sourceTree = "<group>"; };
 		BD56783D28B3ECD5002C1D55 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
 		BD856AB528C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+CellConfiguration.swift"; sourceTree = "<group>"; };
+		BD856AB828C3928D00052BB2 /* UIView+PinnedSubview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+PinnedSubview.swift"; sourceTree = "<group>"; };
+		BD856ABA28C3953B00052BB2 /* TextFieldContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldContentView.swift; sourceTree = "<group>"; };
 		BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Today.swift"; sourceTree = "<group>"; };
 		BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+DataSource.swift"; sourceTree = "<group>"; };
 		BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Today.swift"; sourceTree = "<group>"; };
+		BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentConfiguration+Stateless.swift"; sourceTree = "<group>"; };
 		BDE2B5C8288C35020023F5EB /* Today.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Today.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDE2B5CB288C35020023F5EB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -57,6 +63,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BD856AB728C391E300052BB2 /* ContentViews */ = {
+			isa = PBXGroup;
+			children = (
+				BD856AB828C3928D00052BB2 /* UIView+PinnedSubview.swift */,
+				BD856ABA28C3953B00052BB2 /* TextFieldContentView.swift */,
+				BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */,
+			);
+			path = ContentViews;
+			sourceTree = "<group>";
+		};
 		BD86A9EE288DD56B00E48F62 /* ListViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -90,8 +106,9 @@
 				BDE2B5DF288C384D0023F5EB /* Models */,
 				BDE2B5CB288C35020023F5EB /* AppDelegate.swift */,
 				BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */,
-				BD86A9EE288DD56B00E48F62 /* ListViewController */,
+				BD856AB728C391E300052BB2 /* ContentViews */,
 				BDF4120F28AAEB850030DB9E /* DetailViewController */,
+				BD86A9EE288DD56B00E48F62 /* ListViewController */,
 				BDE2B5D1288C35020023F5EB /* Main.storyboard */,
 				BDE2B5D4288C35070023F5EB /* Assets.xcassets */,
 				BDE2B5D6288C35070023F5EB /* LaunchScreen.storyboard */,
@@ -192,12 +209,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD856AB928C3928D00052BB2 /* UIView+PinnedSubview.swift in Sources */,
 				BD56783E28B3ECD5002C1D55 /* ReminderViewController+Section.swift in Sources */,
 				BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */,
 				BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */,
 				BDF4120E28AAE9800030DB9E /* ReminderViewController.swift in Sources */,
+				BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */,
 				BDE2B5D0288C35020023F5EB /* ReminderListViewController.swift in Sources */,
 				BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */,
+				BD856ABB28C3953B00052BB2 /* TextFieldContentView.swift in Sources */,
 				BD0A784F28AEE0480040DFD7 /* ReminderViewController+Row.swift in Sources */,
 				BD38451D288F274B005FD8EB /* ReminderDoneButton.swift in Sources */,
 				BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */,

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */; };
 		BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */; };
 		BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */; };
+		BD8E908A28C693A4000A4700 /* TextViewContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908928C693A4000A4700 /* TextViewContentView.swift */; };
+		BD8E908C28C694C4000A4700 /* DatePickerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908B28C694C4000A4700 /* DatePickerContentView.swift */; };
 		BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CB288C35020023F5EB /* AppDelegate.swift */; };
 		BDE2B5CE288C35020023F5EB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */; };
 		BDE2B5D0288C35020023F5EB /* ReminderListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2B5CF288C35020023F5EB /* ReminderListViewController.swift */; };
@@ -40,6 +42,8 @@
 		BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+DataSource.swift"; sourceTree = "<group>"; };
 		BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Today.swift"; sourceTree = "<group>"; };
 		BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentConfiguration+Stateless.swift"; sourceTree = "<group>"; };
+		BD8E908928C693A4000A4700 /* TextViewContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewContentView.swift; sourceTree = "<group>"; };
+		BD8E908B28C694C4000A4700 /* DatePickerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerContentView.swift; sourceTree = "<group>"; };
 		BDE2B5C8288C35020023F5EB /* Today.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Today.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDE2B5CB288C35020023F5EB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,8 @@
 				BD856AB828C3928D00052BB2 /* UIView+PinnedSubview.swift */,
 				BD856ABA28C3953B00052BB2 /* TextFieldContentView.swift */,
 				BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */,
+				BD8E908928C693A4000A4700 /* TextViewContentView.swift */,
+				BD8E908B28C694C4000A4700 /* DatePickerContentView.swift */,
 			);
 			path = ContentViews;
 			sourceTree = "<group>";
@@ -211,6 +217,7 @@
 			files = (
 				BD856AB928C3928D00052BB2 /* UIView+PinnedSubview.swift in Sources */,
 				BD56783E28B3ECD5002C1D55 /* ReminderViewController+Section.swift in Sources */,
+				BD8E908C28C694C4000A4700 /* DatePickerContentView.swift in Sources */,
 				BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */,
 				BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */,
 				BDF4120E28AAE9800030DB9E /* ReminderViewController.swift in Sources */,
@@ -218,6 +225,7 @@
 				BDE2B5D0288C35020023F5EB /* ReminderListViewController.swift in Sources */,
 				BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */,
 				BD856ABB28C3953B00052BB2 /* TextFieldContentView.swift in Sources */,
+				BD8E908A28C693A4000A4700 /* TextViewContentView.swift in Sources */,
 				BD0A784F28AEE0480040DFD7 /* ReminderViewController+Row.swift in Sources */,
 				BD38451D288F274B005FD8EB /* ReminderDoneButton.swift in Sources */,
 				BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */,

--- a/Today/ContentViews/DatePickerContentView.swift
+++ b/Today/ContentViews/DatePickerContentView.swift
@@ -1,0 +1,53 @@
+//
+//  DatePickerContentView.swift
+//  Today
+//
+//  Created by Sanghun Park on 05.09.22.
+//
+
+import UIKit
+
+class DatePickerContentView: UIView, UIContentView {
+    
+    /// To customize the content of the configuration and the view.
+    struct Configuration: UIContentConfiguration {
+        var date = Date.now
+        
+        /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
+        func makeContentView() -> UIView & UIContentView {
+            return DatePickerContentView(self)
+        }
+    }
+    
+    let datePicker = UIDatePicker()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubView(datePicker)
+        datePicker.preferredDatePickerStyle = .inline
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("DatePickerContentView - init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        datePicker.date = configuration.date
+    }
+}
+
+/// Extension to return a custom configuration that will pair with the custom `DatePickerContentView`.
+extension UICollectionViewListCell {
+    
+    /// Returns a new `DatePickerContentView.Configuration`.
+    func datePickerConfiguration() -> DatePickerContentView.Configuration {
+        DatePickerContentView.Configuration()
+    }
+}

--- a/Today/ContentViews/TextFieldContentView.swift
+++ b/Today/ContentViews/TextFieldContentView.swift
@@ -1,0 +1,58 @@
+//
+//  TextFieldContentView.swift
+//  Today
+//
+//  Created by Sanghun Park on 03.09.22.
+//
+
+import UIKit
+
+class TextFieldContentView: UIView, UIContentView {
+    
+    /// To customize the content of the configuration and the view.
+    struct Configuration: UIContentConfiguration {
+        var text: String? = ""
+        
+        /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
+        func makeContentView() -> UIView & UIContentView {
+            return TextFieldContentView(self)
+        }
+    }
+    
+    let textField = UITextField()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    /// To fix the height at 44 points, the minimum size for an accessible control.
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 0, height: 44)
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubView(textField, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        textField.clearButtonMode = .whileEditing
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("TextFieldContentView - init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        textField.text = configuration.text
+    }
+}
+
+/// Extension to return a custom configuration that will pair with the custom `TextFieldContentView`.
+extension UICollectionViewListCell {
+    
+    /// Returns a new `TextFieldContentView.Configuration`.
+    func textFieldConfiguration() -> TextFieldContentView.Configuration {
+        TextFieldContentView.Configuration()
+    }
+}

--- a/Today/ContentViews/TextViewContentView.swift
+++ b/Today/ContentViews/TextViewContentView.swift
@@ -1,0 +1,59 @@
+//
+//  TextViewContentView.swift
+//  Today
+//
+//  Created by Sanghun Park on 05.09.22.
+//
+
+import UIKit
+
+class TextViewContentView: UIView, UIContentView {
+    
+    /// To customize the content of the configuration and the view.
+    struct Configuration: UIContentConfiguration {
+        var text: String? = ""
+        
+        /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
+        func makeContentView() -> UIView & UIContentView {
+            return TextViewContentView(self)
+        }
+    }
+    
+    let textView = UITextView()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    /// To fix the height at 44 points, the minimum size for an accessible control.
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 0, height: 44)
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubView(textView, height: 200)
+        textView.backgroundColor = nil
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("TextViewContentView - init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        textView.text = configuration.text
+    }
+}
+
+/// Extension to return a custom configuration that will pair with the custom `TextViewContentView`.
+extension UICollectionViewListCell {
+    
+    /// Returns a new `TextViewContentView.Configuration`.
+    func textViewConfiguration() -> TextViewContentView.Configuration {
+        TextViewContentView.Configuration()
+    }
+}

--- a/Today/ContentViews/UIContentConfiguration+Stateless.swift
+++ b/Today/ContentViews/UIContentConfiguration+Stateless.swift
@@ -1,0 +1,16 @@
+//
+//  UIContentConfiguration+Stateless.swift
+//  Today
+//
+//  Created by Sanghun Park on 05.09.22.
+//
+
+import UIKit
+
+extension UIContentConfiguration {
+    
+    /// Allows a `UIContentConfiguration` to provide a specialized configuration for a given state.
+    func updated(for state: UIConfigurationState) -> Self {
+        return self
+    }
+}

--- a/Today/ContentViews/UIView+PinnedSubview.swift
+++ b/Today/ContentViews/UIView+PinnedSubview.swift
@@ -1,0 +1,27 @@
+//
+//  UIView+PinnedSubview.swift
+//  Today
+//
+//  Created by Sanghun Park on 03.09.22.
+//
+
+import UIKit
+
+extension UIView {
+    
+    func addPinnedSubView(_ subview: UIView, height: CGFloat? = nil, insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)) {
+        
+        addSubview(subview)
+        
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        
+        subview.topAnchor.constraint(equalTo: topAnchor, constant: insets.top).isActive = true
+        subview.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left).isActive = true
+        subview.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1.0 * insets.right).isActive = true
+        subview.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1.0 * insets.bottom).isActive = true
+        if let height = height {
+            subview.heightAnchor.constraint(equalToConstant: height).isActive = true
+        }
+    }
+    
+}

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -1,0 +1,42 @@
+//
+//  ReminderViewController+CellConfiguration.swift
+//  Today
+//
+//  Created by Sanghun Park on 03.09.22.
+//
+
+import UIKit
+
+extension ReminderViewController {
+    
+    /// Configure the appearance of the list view cell for the view mode and return the configuration.
+    func defaultConfiguration(for cell: UICollectionViewListCell, at row: Row) -> UIListContentConfiguration {
+        var contentConfiguration = cell.defaultContentConfiguration()
+        contentConfiguration.text = text(for: row)
+        contentConfiguration.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
+        contentConfiguration.image = row.image
+        return contentConfiguration
+    }
+    
+    /// Configure the appearance of the header view for the view mode and return the configuration.
+    func headerConfiguration(for cell: UICollectionViewListCell, with title: String) -> UIListContentConfiguration {
+        var contentConfiguration = cell.defaultContentConfiguration()
+        contentConfiguration.text = title
+        return contentConfiguration
+    }
+    
+    /// Create appropriate text string for a row type.
+    func text(for row: Row) -> String? {
+        switch row {
+        case .viewDate:
+            return reminder.dueDate.dayText
+        case .viewNotes:
+            return reminder.notes
+        case .viewTime:
+            return reminder.dueDate.formatted(date: .omitted, time: .shortened)
+        case .viewTitle:
+            return reminder.title
+        default: return nil
+        }
+    }
+}

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -32,6 +32,20 @@ extension ReminderViewController {
         return contentConfiguration
     }
     
+    /// Accepts a cell and a title and returns a `DatePickerContentView.Configuration`.
+    func dateConfiguration(for cell: UICollectionViewListCell, with date: Date) -> DatePickerContentView.Configuration {
+        var contentConfiguration = cell.datePickerConfiguration()
+        contentConfiguration.date = date
+        return contentConfiguration
+    }
+    
+    /// Accepts a cell and a title and returns a `TextViewContentView.Configuration`.
+    func notesConfiguration(for cell: UICollectionViewListCell, with notes: String?) -> TextViewContentView.Configuration {
+        var contentConfiguration = cell.textViewConfiguration()
+        contentConfiguration.text = notes
+        return contentConfiguration
+    }
+    
     /// Create appropriate text string for a row type.
     func text(for row: Row) -> String? {
         switch row {

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -25,6 +25,13 @@ extension ReminderViewController {
         return contentConfiguration
     }
     
+    /// Accepts a cell and a title and returns a `TextFieldContentView.Configuration`.
+    func titleConfiguration(for cell: UICollectionViewListCell, with title: String?) -> TextFieldContentView.Configuration {
+        var contentConfiguration = cell.textFieldConfiguration()
+        contentConfiguration.text = title
+        return contentConfiguration
+    }
+    
     /// Create appropriate text string for a row type.
     func text(for row: Row) -> String? {
         switch row {

--- a/Today/DetailViewController/ReminderViewController+Row.swift
+++ b/Today/DetailViewController/ReminderViewController+Row.swift
@@ -18,6 +18,7 @@ extension ReminderViewController {
         case viewNotes
         case viewTime
         case viewTitle
+        case editText(String)
         
         var imageName: String? {
             switch self {

--- a/Today/DetailViewController/ReminderViewController+Row.swift
+++ b/Today/DetailViewController/ReminderViewController+Row.swift
@@ -18,7 +18,8 @@ extension ReminderViewController {
         case viewNotes
         case viewTime
         case viewTitle
-        case editText(String)
+        case editDate(Date)
+        case editText(String?)
         
         var imageName: String? {
             switch self {

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -88,17 +88,9 @@ class ReminderViewController: UICollectionViewController {
         // Add a switch statement to configure cells for different section and row combinations.
         switch (section, row) {
         case (_, .header(let title)):
-            var contentConfiguration = cell.defaultContentConfiguration()
-            contentConfiguration.text = title
-            cell.contentConfiguration = contentConfiguration
+            cell.contentConfiguration = headerConfiguration(for: cell, with: title)
         case (.view, _):
-            // Configure content and appearance
-            var contentConfiguration = cell.defaultContentConfiguration()
-            contentConfiguration.text = text(for: row)
-            contentConfiguration.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
-            contentConfiguration.image = row.image
-            // Apply the content configurateion to cell
-            cell.contentConfiguration = contentConfiguration
+            cell.contentConfiguration = defaultConfiguration(for: cell, at: row)
         default:
             fatalError("Unexpected combination of section and row.")
         }
@@ -133,21 +125,6 @@ class ReminderViewController: UICollectionViewController {
         guard let section = Section(rawValue: sectionNumber) else {  fatalError("Unable to find matching section") }
         
         return section
-    }
-    
-    func text(for row: Row) -> String? {
-        switch row {
-        case .viewDate:
-            return reminder.dueDate.dayText
-        case .viewNotes:
-            return reminder.notes
-        case .viewTime:
-//            return reminder.dueDate.dayAndTimeText
-            return reminder.dueDate.formatted(date: .omitted, time: .shortened)
-        case .viewTitle:
-            return reminder.title
-        default: return nil
-        }
     }
 
     // MARK: UICollectionViewDataSource

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -93,6 +93,10 @@ class ReminderViewController: UICollectionViewController {
             cell.contentConfiguration = defaultConfiguration(for: cell, at: row)
         case (.title, .editText(let title)):
             cell.contentConfiguration = titleConfiguration(for: cell, with: title)
+        case (.date, .editDate(let date)):
+            cell.contentConfiguration = dateConfiguration(for: cell, with: date)
+        case (.notes, .editText(let notes)):
+            cell.contentConfiguration = notesConfiguration(for: cell, with: notes)
         default:
             fatalError("Unexpected combination of section and row.")
         }
@@ -104,8 +108,8 @@ class ReminderViewController: UICollectionViewController {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
         snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
-        snapshot.appendItems([.header(Section.date.name)], toSection: .date)
-        snapshot.appendItems([.header(Section.notes.name)], toSection: .notes)
+        snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
+        snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
         dataSource.apply(snapshot)
     }
     

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -91,6 +91,8 @@ class ReminderViewController: UICollectionViewController {
             cell.contentConfiguration = headerConfiguration(for: cell, with: title)
         case (.view, _):
             cell.contentConfiguration = defaultConfiguration(for: cell, at: row)
+        case (.title, .editText(let title)):
+            cell.contentConfiguration = titleConfiguration(for: cell, with: title)
         default:
             fatalError("Unexpected combination of section and row.")
         }
@@ -101,7 +103,7 @@ class ReminderViewController: UICollectionViewController {
     private func updateSnapShotForEditing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
-        snapshot.appendItems([.header(Section.title.name)], toSection: .title)
+        snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
         snapshot.appendItems([.header(Section.date.name)], toSection: .date)
         snapshot.appendItems([.header(Section.notes.name)], toSection: .notes)
         dataSource.apply(snapshot)


### PR DESCRIPTION
- Add capabilities to the app’s editing mode that transform a view-only list of reminder details into editable controls.
- Replace the content views of the detail view list cells with editable content views that are customized for the type of information in each cell.