### PR TITLE
Feature/editing reminders

### DIFF
--- a/Today/ContentViews/DatePickerContentView.swift
+++ b/Today/ContentViews/DatePickerContentView.swift
@@ -12,6 +12,7 @@ class DatePickerContentView: UIView, UIContentView {
     /// To customize the content of the configuration and the view.
     struct Configuration: UIContentConfiguration {
         var date = Date.now
+        var onChange: (Date)->Void = { _ in }
         
         /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
         func makeContentView() -> UIView & UIContentView {
@@ -30,6 +31,7 @@ class DatePickerContentView: UIView, UIContentView {
         self.configuration = configuration
         super.init(frame: .zero)
         addPinnedSubView(datePicker)
+        datePicker.addTarget(self, action: #selector(didPick(_:)), for: .valueChanged)
         datePicker.preferredDatePickerStyle = .inline
     }
     
@@ -40,6 +42,11 @@ class DatePickerContentView: UIView, UIContentView {
     func configure(configuration: UIContentConfiguration) {
         guard let configuration = configuration as? Configuration else { return }
         datePicker.date = configuration.date
+    }
+    
+    @objc private func didPick(_ sender: UIDatePicker) {
+        guard let configuration = configuration as? DatePickerContentView.Configuration else { return }
+        configuration.onChange(sender.date)
     }
 }
 

--- a/Today/ContentViews/TextFieldContentView.swift
+++ b/Today/ContentViews/TextFieldContentView.swift
@@ -12,6 +12,7 @@ class TextFieldContentView: UIView, UIContentView {
     /// To customize the content of the configuration and the view.
     struct Configuration: UIContentConfiguration {
         var text: String? = ""
+        var onChange: (String)->Void = { _ in }
         
         /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
         func makeContentView() -> UIView & UIContentView {
@@ -35,6 +36,7 @@ class TextFieldContentView: UIView, UIContentView {
         self.configuration = configuration
         super.init(frame: .zero)
         addPinnedSubView(textField, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        textField.addTarget(self, action: #selector(didChange(_:)), for: .editingChanged)
         textField.clearButtonMode = .whileEditing
     }
     
@@ -45,6 +47,11 @@ class TextFieldContentView: UIView, UIContentView {
     func configure(configuration: UIContentConfiguration) {
         guard let configuration = configuration as? Configuration else { return }
         textField.text = configuration.text
+    }
+    
+    @objc private func didChange(_ sender: UITextField) {
+        guard let configuration = configuration as? TextFieldContentView.Configuration else { return }
+        configuration.onChange(textField.text ?? "")
     }
 }
 

--- a/Today/ContentViews/TextViewContentView.swift
+++ b/Today/ContentViews/TextViewContentView.swift
@@ -12,6 +12,7 @@ class TextViewContentView: UIView, UIContentView {
     /// To customize the content of the configuration and the view.
     struct Configuration: UIContentConfiguration {
         var text: String? = ""
+        var onChange: (String)->Void = { _ in }
         
         /// The final behavior that need to include to conform to the `UIContentConfiguration` protocol.
         func makeContentView() -> UIView & UIContentView {
@@ -36,6 +37,7 @@ class TextViewContentView: UIView, UIContentView {
         super.init(frame: .zero)
         addPinnedSubView(textView, height: 200)
         textView.backgroundColor = nil
+        textView.delegate = self
         textView.font = UIFont.preferredFont(forTextStyle: .body)
     }
     
@@ -55,5 +57,13 @@ extension UICollectionViewListCell {
     /// Returns a new `TextViewContentView.Configuration`.
     func textViewConfiguration() -> TextViewContentView.Configuration {
         TextViewContentView.Configuration()
+    }
+}
+
+extension TextViewContentView: UITextViewDelegate {
+    
+    func textViewDidChange(_ textView: UITextView) {
+        guard let  configuration = configuration as? TextViewContentView.Configuration else { return }
+        configuration.onChange(textView.text)
     }
 }

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -49,6 +49,9 @@ extension ReminderViewController {
     func notesConfiguration(for cell: UICollectionViewListCell, with notes: String?) -> TextViewContentView.Configuration {
         var contentConfiguration = cell.textViewConfiguration()
         contentConfiguration.text = notes
+        contentConfiguration.onChange = { [weak self] notes in
+            self?.workingReminder.notes = notes
+        }
         return contentConfiguration
     }
     

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -29,6 +29,9 @@ extension ReminderViewController {
     func titleConfiguration(for cell: UICollectionViewListCell, with title: String?) -> TextFieldContentView.Configuration {
         var contentConfiguration = cell.textFieldConfiguration()
         contentConfiguration.text = title
+        contentConfiguration.onChange = { [weak self] title in
+            self?.workingReminder.title = title
+        }
         return contentConfiguration
     }
     

--- a/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
+++ b/Today/DetailViewController/ReminderViewController+CellConfiguration.swift
@@ -39,6 +39,9 @@ extension ReminderViewController {
     func dateConfiguration(for cell: UICollectionViewListCell, with date: Date) -> DatePickerContentView.Configuration {
         var contentConfiguration = cell.datePickerConfiguration()
         contentConfiguration.date = date
+        contentConfiguration.onChange = { [weak self] dueDate in
+            self?.workingReminder.dueDate = dueDate
+        }
         return contentConfiguration
     }
     

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-private let reuseIdentifier = "Cell"
-
 /// Lay out the list of reminder detailes and supplies the list with the reminder details data.
 class ReminderViewController: UICollectionViewController {
     
@@ -16,10 +14,12 @@ class ReminderViewController: UICollectionViewController {
     private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
     
     var reminder: Reminder
+    var workingReminder: Reminder   // temporary reminder that stores the edits until the user chooses to save or discard.
     private var dataSource: DataSource!
     
     init(reminder: Reminder) {
         self.reminder = reminder
+        self.workingReminder = reminder
         
         // a list compositional layout contains only the layout information needed for a list
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
@@ -36,12 +36,13 @@ class ReminderViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        /*
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
 
         // Register cell classes
         // self.collectionView!.register(UICollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
-
+        */
         // Do any additional setup after loading the view.
         
         // Create new cell registration
@@ -72,10 +73,10 @@ class ReminderViewController: UICollectionViewController {
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
         if editing {
-            updateSnapShotForEditing()
+            prepareForEditing()
         }
         else {
-            updateSnapshotForViewing()
+            prepareForViewing()
         }
     }
     
@@ -104,6 +105,10 @@ class ReminderViewController: UICollectionViewController {
         cell.tintColor = .todayPrimaryTint
     }
     
+    private func prepareForEditing() {
+        updateSnapShotForEditing()
+    }
+    
     private func updateSnapShotForEditing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
@@ -111,6 +116,13 @@ class ReminderViewController: UICollectionViewController {
         snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
         snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
         dataSource.apply(snapshot)
+    }
+    
+    private func prepareForViewing() {
+        if workingReminder != reminder {
+            reminder = workingReminder
+        }
+        updateSnapshotForViewing()
     }
     
     private func updateSnapshotForViewing() {

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -105,7 +105,15 @@ class ReminderViewController: UICollectionViewController {
         cell.tintColor = .todayPrimaryTint
     }
     
+    @objc func didCancelEdit() {
+        // reset the working reminder
+        workingReminder = reminder
+        // make the button to show "Edit" again
+        setEditing(false, animated: true)
+    }
+    
     private func prepareForEditing() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(didCancelEdit))
         updateSnapShotForEditing()
     }
     
@@ -119,6 +127,7 @@ class ReminderViewController: UICollectionViewController {
     }
     
     private func prepareForViewing() {
+        navigationItem.leftBarButtonItem = nil
         if workingReminder != reminder {
             reminder = workingReminder
         }

--- a/Today/DetailViewController/ReminderViewController.swift
+++ b/Today/DetailViewController/ReminderViewController.swift
@@ -13,13 +13,19 @@ class ReminderViewController: UICollectionViewController {
     private typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
     private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
     
-    var reminder: Reminder
+    var reminder: Reminder {
+        didSet {
+            onChange(reminder)
+        }
+    }
     var workingReminder: Reminder   // temporary reminder that stores the edits until the user chooses to save or discard.
+    var onChange: (Reminder)->Void
     private var dataSource: DataSource!
     
-    init(reminder: Reminder) {
+    init(reminder: Reminder, onChange: @escaping (Reminder)->Void) {
         self.reminder = reminder
         self.workingReminder = reminder
+        self.onChange = onChange
         
         // a list compositional layout contains only the layout information needed for a list
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -48,7 +48,10 @@ class ReminderListViewController: UICollectionViewController {
     
     func showDetail(for id: Reminder.ID) {
         let reminder = reminder(for: id)
-        let viewController = ReminderViewController(reminder: reminder)
+        let viewController = ReminderViewController(reminder: reminder) { [weak self] reminder in
+            self?.update(reminder, with: reminder.id)
+            self?.updateSnapshot(reloading: [reminder.id])
+        }
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/Today/Models/Reminder.swift
+++ b/Today/Models/Reminder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Reminder: Identifiable {
+struct Reminder: Equatable, Identifiable {
     var id: String = UUID().uuidString
     var title: String
     var dueDate: Date


### PR DESCRIPTION
- Add an editing mode to the app that lets users edit the details of the reminder.
- When the user taps the Done button, the app saves the reminder edits, returns to view mode, and updates all relevant views.
- If the user taps the Cancel button, the app discards the changes and returns to view mode.
- Observe changes to reminder data, and communicate those changes throughout the view hierarchy.