### PR TITLE
Feature/filtering reminders

### DIFF
--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */; };
 		BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */; };
 		BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */; };
+		BD8836AF28C807DD00228471 /* ReminderListStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8836AE28C807DD00228471 /* ReminderListStyle.swift */; };
 		BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */; };
 		BD8E908A28C693A4000A4700 /* TextViewContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908928C693A4000A4700 /* TextViewContentView.swift */; };
 		BD8E908C28C694C4000A4700 /* DatePickerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E908B28C694C4000A4700 /* DatePickerContentView.swift */; };
@@ -41,6 +42,7 @@
 		BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Today.swift"; sourceTree = "<group>"; };
 		BD86A9EF288DD5D200E48F62 /* ReminderListViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+DataSource.swift"; sourceTree = "<group>"; };
 		BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Today.swift"; sourceTree = "<group>"; };
+		BD8836AE28C807DD00228471 /* ReminderListStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderListStyle.swift; sourceTree = "<group>"; };
 		BD8E908728C6842E000A4700 /* UIContentConfiguration+Stateless.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentConfiguration+Stateless.swift"; sourceTree = "<group>"; };
 		BD8E908928C693A4000A4700 /* TextViewContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewContentView.swift; sourceTree = "<group>"; };
 		BD8E908B28C694C4000A4700 /* DatePickerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerContentView.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				BDE2B5E0288C386B0023F5EB /* Reminder.swift */,
 				BD86A9EB288C7EDA00E48F62 /* Date+Today.swift */,
 				BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */,
+				BD8836AE28C807DD00228471 /* ReminderListStyle.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -221,6 +224,7 @@
 				BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */,
 				BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */,
 				BDF4120E28AAE9800030DB9E /* ReminderViewController.swift in Sources */,
+				BD8836AF28C807DD00228471 /* ReminderListStyle.swift in Sources */,
 				BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */,
 				BDE2B5D0288C35020023F5EB /* ReminderListViewController.swift in Sources */,
 				BD86A9EC288C7EDA00E48F62 /* Date+Today.swift in Sources */,

--- a/Today/ListViewController/ReminderListViewController+Actions.swift
+++ b/Today/ListViewController/ReminderListViewController+Actions.swift
@@ -33,4 +33,9 @@ extension ReminderListViewController {
     @objc func didCancelAdd(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }
+    
+    @objc func didChangeListStyle(_ sender: UISegmentedControl) {
+        listStyle = ReminderListStyle(rawValue: sender.selectedSegmentIndex) ?? .today
+        updateSnapshot()
+    }
 }

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -23,7 +23,7 @@ extension ReminderListViewController {
         NSLocalizedString("Not completed", comment: "Reminder not completed value")
     }
     
-    // Update and apply a snapshot to update user interface when data changes.
+    /// Update and apply a snapshot to update user interface when data changes.
     func updateSnapshot(reloading idsThatChanged: [Reminder.ID] = []) {
         // Sepcifying an empty array as the default value for the parameter lets the app call the method from `viewDidLoad()` without providing identifiers.
         

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -24,13 +24,18 @@ extension ReminderListViewController {
     }
     
     // Update and apply a snapshot to update user interface when data changes.
-    func updateSnapshot(reloading ids: [Reminder.ID] = []) {
+    func updateSnapshot(reloading idsThatChanged: [Reminder.ID] = []) {
         // Sepcifying an empty array as the default value for the parameter lets the app call the method from `viewDidLoad()` without providing identifiers.
+        
+        // Filter IDs to include only id that correspond to reminders in the filteredReminders array
+        let ids = idsThatChanged.filter { id in 
+            filteredReminders.contains(where: { $0.id == id })
+        }
         
         // Create an empty snapshot, and append sections and items.
         var snapshot = Snapshot()
         snapshot.appendSections([0])
-        snapshot.appendItems(reminders.map { $0.id })
+        snapshot.appendItems(filteredReminders.map { $0.id })
         if !ids.isEmpty {
             snapshot.reloadItems(ids)
         }

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -47,6 +47,7 @@ class ReminderListViewController: UICollectionViewController {
         navigationItem.rightBarButtonItem = addButton
         
         listStyleSegmentedControl.selectedSegmentIndex = listStyle.rawValue
+        listStyleSegmentedControl.addTarget(self, action: #selector(didChangeListStyle(_:)), for: .valueChanged)
         navigationItem.titleView = listStyleSegmentedControl
         
         updateSnapshot()

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -15,6 +15,13 @@ class ReminderListViewController: UICollectionViewController {
     
     // reminders property to configure snapshots and collection view cells. Init with sample data.
     var reminders: [Reminder] = Reminder.sampleData
+    
+    var filteredReminders: [Reminder] {
+        return reminders
+            .filter { listStyle.shouldInclude(date: $0.dueDate) }
+            .sorted { $0.dueDate < $1.dueDate }
+    }
+    var listStyle: ReminderListStyle = .today
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -45,7 +52,7 @@ class ReminderListViewController: UICollectionViewController {
     // Not showing the item that the user tapped as selected.
     override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         
-        let id = reminders[indexPath.item].id
+        let id = filteredReminders[indexPath.item].id
         showDetail(for: id)
         return false
     }

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -22,6 +22,9 @@ class ReminderListViewController: UICollectionViewController {
             .sorted { $0.dueDate < $1.dueDate }
     }
     var listStyle: ReminderListStyle = .today
+    let listStyleSegmentedControl = UISegmentedControl(items: [
+        ReminderListStyle.today.name, ReminderListStyle.future.name, ReminderListStyle.all.name
+    ])
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,6 +45,9 @@ class ReminderListViewController: UICollectionViewController {
         let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didPressAddButton(_:)))
         addButton.accessibilityLabel = NSLocalizedString("Add reminder", comment: "Add button accessibility label")
         navigationItem.rightBarButtonItem = addButton
+        
+        listStyleSegmentedControl.selectedSegmentIndex = listStyle.rawValue
+        navigationItem.titleView = listStyleSegmentedControl
         
         updateSnapshot()
         

--- a/Today/Models/ReminderListStyle.swift
+++ b/Today/Models/ReminderListStyle.swift
@@ -12,6 +12,17 @@ enum ReminderListStyle: Int {
     case future
     case all
     
+    var name: String {
+        switch self {
+        case .today:
+            return NSLocalizedString("Today", comment: "Today style name")
+        case .future:
+            return NSLocalizedString("Future", comment: "Future style name")
+        case .all:
+            return NSLocalizedString("All", comment: "All style name")
+        }
+    }
+    
     func shouldInclude(date: Date) -> Bool {
         let isInToday = Locale.current.calendar.isDateInToday(date)
         switch self {

--- a/Today/Models/ReminderListStyle.swift
+++ b/Today/Models/ReminderListStyle.swift
@@ -1,0 +1,26 @@
+//
+//  ReminderListStyle.swift
+//  Today
+//
+//  Created by Sanghun Park on 07.09.22.
+//
+
+import Foundation
+
+enum ReminderListStyle: Int {
+    case today
+    case future
+    case all
+    
+    func shouldInclude(date: Date) -> Bool {
+        let isInToday = Locale.current.calendar.isDateInToday(date)
+        switch self {
+        case .today:
+            return isInToday
+        case .future:
+            return (date > Date.now) && !isInToday
+        case .all:
+            return true
+        }
+    }
+}


### PR DESCRIPTION
For users to more easily access the reminders on the app’s main view.
- Create a `ListStyle` enumeration that separates reminders into three categories: Today, Future, and All. 
- Add a segmented control that lets users select different styles for the reminders list.

Added a control for filtering reminders by due date. Will add some polish to the app’s user interface in the next.