### PR TITLE
Feature/sync with reminders+eventkit

### DIFF
--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */; };
 		BDF82EBB28CA8B3500AE34A4 /* Reminder+EKReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */; };
 		BDF82EBD28CA8DF700AE34A4 /* ReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */; };
+		BDF82EBF28CB750600AE34A4 /* EKReminder+Reminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBE28CB750600AE34A4 /* EKReminder+Reminder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+AsyncFetch.swift"; sourceTree = "<group>"; };
 		BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reminder+EKReminder.swift"; sourceTree = "<group>"; };
 		BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderStore.swift; sourceTree = "<group>"; };
+		BDF82EBE28CB750600AE34A4 /* EKReminder+Reminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKReminder+Reminder.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +152,7 @@
 				BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */,
 				BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */,
 				BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */,
+				BDF82EBE28CB750600AE34A4 /* EKReminder+Reminder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -261,6 +264,7 @@
 				BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */,
 				BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */,
 				BDF82EBD28CA8DF700AE34A4 /* ReminderStore.swift in Sources */,
+				BDF82EBF28CB750600AE34A4 /* EKReminder+Reminder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		BDF82EB728CA854000AE34A4 /* TodayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB628CA854000AE34A4 /* TodayError.swift */; };
 		BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */; };
 		BDF82EBB28CA8B3500AE34A4 /* Reminder+EKReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */; };
+		BDF82EBD28CA8DF700AE34A4 /* ReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +67,7 @@
 		BDF82EB628CA854000AE34A4 /* TodayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayError.swift; sourceTree = "<group>"; };
 		BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+AsyncFetch.swift"; sourceTree = "<group>"; };
 		BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reminder+EKReminder.swift"; sourceTree = "<group>"; };
+		BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +149,7 @@
 				BDF82EB628CA854000AE34A4 /* TodayError.swift */,
 				BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */,
 				BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */,
+				BDF82EBC28CA8DF700AE34A4 /* ReminderStore.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 				BDE2B5E1288C386B0023F5EB /* Reminder.swift in Sources */,
 				BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */,
 				BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */,
+				BDF82EBD28CA8DF700AE34A4 /* ReminderStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		BDF4120E28AAE9800030DB9E /* ReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4120D28AAE9800030DB9E /* ReminderViewController.swift */; };
 		BDF7936728CA1E5A0094B795 /* ProgressHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF7936628CA1E5A0094B795 /* ProgressHeaderView.swift */; };
 		BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */; };
+		BDF82EB728CA854000AE34A4 /* TodayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB628CA854000AE34A4 /* TodayError.swift */; };
+		BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +62,8 @@
 		BDF4120D28AAE9800030DB9E /* ReminderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderViewController.swift; sourceTree = "<group>"; };
 		BDF7936628CA1E5A0094B795 /* ProgressHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHeaderView.swift; sourceTree = "<group>"; };
 		BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CAGradientLayer+ListStyle.swift"; sourceTree = "<group>"; };
+		BDF82EB628CA854000AE34A4 /* TodayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayError.swift; sourceTree = "<group>"; };
+		BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+AsyncFetch.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,12 +121,12 @@
 			isa = PBXGroup;
 			children = (
 				BDE2B5DF288C384D0023F5EB /* Models */,
-				BDE2B5CB288C35020023F5EB /* AppDelegate.swift */,
-				BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */,
 				BD856AB728C391E300052BB2 /* ContentViews */,
 				BDF4120F28AAEB850030DB9E /* DetailViewController */,
 				BD86A9EE288DD56B00E48F62 /* ListViewController */,
 				BDE2B5D1288C35020023F5EB /* Main.storyboard */,
+				BDE2B5CB288C35020023F5EB /* AppDelegate.swift */,
+				BDE2B5CD288C35020023F5EB /* SceneDelegate.swift */,
 				BDE2B5D4288C35070023F5EB /* Assets.xcassets */,
 				BDE2B5D6288C35070023F5EB /* LaunchScreen.storyboard */,
 				BDE2B5D9288C35070023F5EB /* Info.plist */,
@@ -138,6 +142,8 @@
 				BD86A9F1288DDBA500E48F62 /* UIColor+Today.swift */,
 				BD8836AE28C807DD00228471 /* ReminderListStyle.swift */,
 				BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */,
+				BDF82EB628CA854000AE34A4 /* TodayError.swift */,
+				BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -230,6 +236,7 @@
 				BD8E908C28C694C4000A4700 /* DatePickerContentView.swift in Sources */,
 				BD86A9F2288DDBA500E48F62 /* UIColor+Today.swift in Sources */,
 				BD38451F288F3EB6005FD8EB /* ReminderListViewController+Actions.swift in Sources */,
+				BDF82EB728CA854000AE34A4 /* TodayError.swift in Sources */,
 				BDF4120E28AAE9800030DB9E /* ReminderViewController.swift in Sources */,
 				BD8836AF28C807DD00228471 /* ReminderListStyle.swift in Sources */,
 				BD8E908828C6842E000A4700 /* UIContentConfiguration+Stateless.swift in Sources */,
@@ -242,6 +249,7 @@
 				BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */,
 				BD856AB628C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BDE2B5CE288C35020023F5EB /* SceneDelegate.swift in Sources */,
+				BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */,
 				BDE2B5E1288C386B0023F5EB /* Reminder.swift in Sources */,
 				BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */,
 				BD86A9F0288DD5D200E48F62 /* ReminderListViewController+DataSource.swift in Sources */,

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 				DEVELOPMENT_TEAM = LL863NAQHT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Today/Info.plist;
+				INFOPLIST_KEY_NSRemindersUsageDescription = "Your reminders can help you stay on track.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -438,6 +439,7 @@
 				DEVELOPMENT_TEAM = LL863NAQHT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Today/Info.plist;
+				INFOPLIST_KEY_NSRemindersUsageDescription = "Your reminders can help you stay on track.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/Today.xcodeproj/project.pbxproj
+++ b/Today.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */; };
 		BDF82EB728CA854000AE34A4 /* TodayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB628CA854000AE34A4 /* TodayError.swift */; };
 		BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */; };
+		BDF82EBB28CA8B3500AE34A4 /* Reminder+EKReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +65,7 @@
 		BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CAGradientLayer+ListStyle.swift"; sourceTree = "<group>"; };
 		BDF82EB628CA854000AE34A4 /* TodayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayError.swift; sourceTree = "<group>"; };
 		BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+AsyncFetch.swift"; sourceTree = "<group>"; };
+		BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reminder+EKReminder.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				BDF82EB428CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift */,
 				BDF82EB628CA854000AE34A4 /* TodayError.swift */,
 				BDF82EB828CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift */,
+				BDF82EBA28CA8B3500AE34A4 /* Reminder+EKReminder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -249,6 +252,7 @@
 				BDE2B5CC288C35020023F5EB /* AppDelegate.swift in Sources */,
 				BD856AB628C38C0400052BB2 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BDE2B5CE288C35020023F5EB /* SceneDelegate.swift in Sources */,
+				BDF82EBB28CA8B3500AE34A4 /* Reminder+EKReminder.swift in Sources */,
 				BDF82EB928CA85F200AE34A4 /* EKEventStore+AsyncFetch.swift in Sources */,
 				BDE2B5E1288C386B0023F5EB /* Reminder.swift in Sources */,
 				BDF82EB528CA3DD100AE34A4 /* CAGradientLayer+ListStyle.swift in Sources */,

--- a/Today/ListViewController/ReminderListViewController+Actions.swift
+++ b/Today/ListViewController/ReminderListViewController+Actions.swift
@@ -9,6 +9,10 @@ import UIKit
 
 extension ReminderListViewController {
     
+    @objc func eventStoreChanged(_ notification: NSNotification) {
+        reminderStoreChanged()
+    }
+    
     @objc func didPressDoneButton(_ sender: ReminderDoneButton) {
         guard let id = sender.id else { return }
         completeReminder(with: id)

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -163,8 +163,15 @@ extension ReminderListViewController {
     }
     
     func deleteReminder(with id: Reminder.ID) {
-        let index = reminders.indexOfReminder(with: id)
-        reminders.remove(at: index)
+        do {
+            try reminderStore.remove(with: id)
+            let index = reminders.indexOfReminder(with: id)
+            reminders.remove(at: index)
+        }
+        catch TodayError.accessDenied { }
+        catch {
+            showError(error)
+        }
     }
     
     func reminder(for id: Reminder.ID) -> Reminder {

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -128,6 +128,7 @@ extension ReminderListViewController {
             do {
                 try await reminderStore.requestAccess()
                 reminders = try await reminderStore.readAll()
+                NotificationCenter.default.addObserver(self, selector: #selector(eventStoreChanged(_:)), name: .EKEventStoreChanged, object: nil)
             }
             catch TodayError.accessDenied, TodayError.accessRestricted {
                 #if DEBUG
@@ -137,6 +138,13 @@ extension ReminderListViewController {
             catch {
                 showError(error)
             }
+            updateSnapshot()
+        }
+    }
+    
+    func reminderStoreChanged() {
+        Task {
+            reminders = try await reminderStore.readAll()
             updateSnapshot()
         }
     }

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -173,7 +173,14 @@ extension ReminderListViewController {
     }
     
     func update(_ reminder: Reminder, with id: Reminder.ID) {
-        let index = reminders.indexOfReminder(with: id)
-        reminders[index] = reminder
+        do {
+            try reminderStore.save(reminder)
+            let index = reminders.indexOfReminder(with: id)
+            reminders[index] = reminder
+        }
+        catch TodayError.accessDenied { }
+        catch {
+            showError(error)
+        }
     }
 }

--- a/Today/ListViewController/ReminderListViewController+DataSource.swift
+++ b/Today/ListViewController/ReminderListViewController+DataSource.swift
@@ -150,7 +150,16 @@ extension ReminderListViewController {
     }
     
     func add(_ reminder: Reminder) {
-        reminders.append(reminder)
+        var reminder = reminder
+        do {
+            let idFromStore = try reminderStore.save(reminder)
+            reminder.id = idFromStore
+            reminders.append(reminder)
+        }
+        catch TodayError.accessDenied { }
+        catch {
+            showError(error)
+        }
     }
     
     func deleteReminder(with id: Reminder.ID) {

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -13,8 +13,8 @@ class ReminderListViewController: UICollectionViewController {
     // SHOULD initialize the data source with guarantee that the optional has a value
     var dataSource: DataSource!
     
-    // reminders property to configure snapshots and collection view cells. Init with sample data.
-    var reminders: [Reminder] = Reminder.sampleData
+    // reminders property to configure snapshots and collection view cells.
+    var reminders: [Reminder] = []
     
     var filteredReminders: [Reminder] {
         return reminders
@@ -74,6 +74,9 @@ class ReminderListViewController: UICollectionViewController {
         
         // Assign the data source to the collection view.
         collectionView.dataSource = dataSource
+        
+        // Prepare reminder store 
+        prepareReminderStore()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Today/ListViewController/ReminderListViewController.swift
+++ b/Today/ListViewController/ReminderListViewController.swift
@@ -113,6 +113,16 @@ class ReminderListViewController: UICollectionViewController {
         }
         navigationController?.pushViewController(viewController, animated: true)
     }
+    
+    func showError(_ error: Error) {
+        let alertTitle = NSLocalizedString("Error", comment: "Error alert title")
+        let alert = UIAlertController(title: alertTitle, message: error.localizedDescription, preferredStyle: .alert)
+        let actionTitle = NSLocalizedString("OK", comment: "Alert OK button title")
+        alert.addAction(UIAlertAction(title: actionTitle, style: .default, handler: { [weak self] _ in
+            self?.dismiss(animated: true)
+        }))
+        present(alert, animated: true, completion: nil)
+    }
 
     private func listLayout() -> UICollectionViewCompositionalLayout {
         

--- a/Today/Models/EKEventStore+AsyncFetch.swift
+++ b/Today/Models/EKEventStore+AsyncFetch.swift
@@ -1,0 +1,26 @@
+//
+//  EKEventStore+AsyncFetch.swift
+//  Today
+//
+//  Created by Sanghun Park on 08.09.22.
+//
+
+import Foundation
+import EventKit
+
+extension EKEventStore {
+    
+    func fetchReminders(matching predicate: NSPredicate) async throws -> [EKReminder] {
+        
+        try await withCheckedThrowingContinuation { continuation in
+            fetchReminders(matching: predicate) { reminders in
+                if let reminders = reminders {
+                    continuation.resume(returning: reminders)
+                }
+                else {
+                    continuation.resume(throwing: TodayError.failedReadingReminders)
+                }
+            }
+        }
+    }
+}

--- a/Today/Models/EKReminder+Reminder.swift
+++ b/Today/Models/EKReminder+Reminder.swift
@@ -1,0 +1,29 @@
+//
+//  EKReminder+Reminder.swift
+//  Today
+//
+//  Created by Sanghun Park on 09.09.22.
+//
+
+import Foundation
+import EventKit
+
+extension EKReminder {
+    
+    func update(using reminder: Reminder, in store: EKEventStore) {
+        self.title = reminder.title
+        self.notes = reminder.notes
+        self.isCompleted = reminder.isComplete
+        self.calendar = store.defaultCalendarForNewReminders()
+        self.alarms?.forEach { alarm in
+            guard let absoluteDate = alarm.absoluteDate else { return }
+            let comparison = Locale.current.calendar.compare(reminder.dueDate, to: absoluteDate, toGranularity: .minute)
+            if comparison != .orderedSame {
+                removeAlarm(alarm)
+            }
+        }
+        if !hasAlarms {
+            addAlarm(EKAlarm(absoluteDate: reminder.dueDate))
+        }
+    }
+}

--- a/Today/Models/Reminder+EKReminder.swift
+++ b/Today/Models/Reminder+EKReminder.swift
@@ -1,0 +1,25 @@
+//
+//  Reminder+EKReminder.swift
+//  Today
+//
+//  Created by Sanghun Park on 08.09.22.
+//
+
+import Foundation
+import EventKit
+
+extension Reminder {
+    
+    init(with ekReminder: EKReminder) throws {
+        
+        guard let dueDate = ekReminder.alarms?.first?.absoluteDate else {
+            throw TodayError.reminderHasNoDueDate
+        }
+        
+        self.id = ekReminder.calendarItemIdentifier
+        self.title = ekReminder.title
+        self.dueDate = dueDate
+        self.notes = ekReminder.notes
+        self.isComplete = ekReminder.isCompleted
+    }
+}

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -17,6 +17,26 @@ class ReminderStore {
         EKEventStore.authorizationStatus(for: .reminder) == .authorized
     }
     
+    func requestAccess() async throws {
+        let status = EKEventStore.authorizationStatus(for: .reminder)
+        
+        switch status {
+        case .notDetermined:
+            let accessGranted = try await ekStore.requestAccess(to: .reminder)
+            guard accessGranted else {
+                throw TodayError.accessDenied
+            }
+        case .restricted:
+            throw TodayError.accessRestricted
+        case .denied:
+            throw TodayError.accessDenied
+        case .authorized:
+            return
+        @unknown default:
+            throw TodayError.unknown
+        }
+    }
+    
     func readAll() async throws -> [Reminder] {
         guard isAvailable else {
             throw TodayError.accessDenied

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -62,4 +62,21 @@ class ReminderStore {
         }
         return reminders
     }
+    
+    @discardableResult
+    func save(_ reminder: Reminder) throws -> Reminder.ID {
+        guard isAvailable else {
+            throw TodayError.accessDenied
+        }
+        let ekReminder: EKReminder
+        do {
+            ekReminder = try read(with: reminder.id)
+        }
+        catch {
+            ekReminder = EKReminder(eventStore: ekStore)
+        }
+        ekReminder.update(using: reminder, in: ekStore)
+        try ekStore.save(ekReminder, commit: true)
+        return ekReminder.calendarItemIdentifier
+    }
 }

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -37,6 +37,14 @@ class ReminderStore {
         }
     }
     
+    private func read(with id: Reminder.ID) throws -> EKReminder {
+        guard let ekReminder = ekStore.calendarItem(withIdentifier: id) as? EKReminder else {
+            throw TodayError.failedReadingCalendarItem
+        }
+        
+        return ekReminder
+    }
+    
     func readAll() async throws -> [Reminder] {
         guard isAvailable else {
             throw TodayError.accessDenied

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -63,6 +63,14 @@ class ReminderStore {
         return reminders
     }
     
+    func remove(with id: Reminder.ID) throws {
+        guard isAvailable else {
+            throw TodayError.accessDenied
+        }
+        let ekReminder = try read(with: id)
+        try ekStore.remove(ekReminder, commit: true)
+    }
+    
     @discardableResult
     func save(_ reminder: Reminder) throws -> Reminder.ID {
         guard isAvailable else {

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -1,0 +1,19 @@
+//
+//  ReminderStore.swift
+//  Today
+//
+//  Created by Sanghun Park on 08.09.22.
+//
+
+import Foundation
+import EventKit
+
+class ReminderStore {
+    static let shared = ReminderStore()
+    
+    private let ekStore = EKEventStore()
+    
+    var isAvailable: Bool {
+        EKEventStore.authorizationStatus(for: .reminder) == .authorized
+    }
+}

--- a/Today/Models/ReminderStore.swift
+++ b/Today/Models/ReminderStore.swift
@@ -16,4 +16,22 @@ class ReminderStore {
     var isAvailable: Bool {
         EKEventStore.authorizationStatus(for: .reminder) == .authorized
     }
+    
+    func readAll() async throws -> [Reminder] {
+        guard isAvailable else {
+            throw TodayError.accessDenied
+        }
+        
+        let predicate = ekStore.predicateForReminders(in: nil)
+        let ekReminders = try await ekStore.fetchReminders(matching: predicate)
+        let reminders: [Reminder] = try ekReminders.compactMap { ekReminder in
+            do {
+                return try Reminder(with: ekReminder)
+            }
+            catch TodayError.reminderHasNoDueDate {
+                return nil
+            }
+        }
+        return reminders
+    }
 }

--- a/Today/Models/TodayError.swift
+++ b/Today/Models/TodayError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum TodayError: LocalizedError {
     case accessDenied
     case accessRestricted
+    case failedReadingCalendarItem
     case failedReadingReminders
     case reminderHasNoDueDate
     case unknown
@@ -20,6 +21,8 @@ enum TodayError: LocalizedError {
             return NSLocalizedString("The app doesn't have permission to read reminders.", comment: "access denied error description")
         case .accessRestricted:
             return NSLocalizedString("This device doesn't allow access to reminders.", comment: "access restricted error description")
+        case .failedReadingCalendarItem:
+            return NSLocalizedString("Failed to read a calendar item.", comment: "failed reading calendar item error description")
         case .failedReadingReminders:
             return NSLocalizedString("Failed to read reminders.", comment: "failed reading reminders error description")
         case .reminderHasNoDueDate:

--- a/Today/Models/TodayError.swift
+++ b/Today/Models/TodayError.swift
@@ -9,17 +9,23 @@ import Foundation
 
 enum TodayError: LocalizedError {
     case accessDenied
+    case accessRestricted
     case failedReadingReminders
     case reminderHasNoDueDate
+    case unknown
     
     var errorDescription: String? {
         switch self {
         case .accessDenied:
             return NSLocalizedString("The app doesn't have permission to read reminders.", comment: "access denied error description")
+        case .accessRestricted:
+            return NSLocalizedString("This device doesn't allow access to reminders.", comment: "access restricted error description")
         case .failedReadingReminders:
             return NSLocalizedString("Failed to read reminders.", comment: "failed reading reminders error description")
         case .reminderHasNoDueDate:
             return NSLocalizedString("A reminder has no due date.", comment: "reminder has no due date error description")
+        case .unknown:
+            return NSLocalizedString("An unknown error occurred.", comment: "unknown error description")
         }
     }
 }

--- a/Today/Models/TodayError.swift
+++ b/Today/Models/TodayError.swift
@@ -8,11 +8,14 @@
 import Foundation
 
 enum TodayError: LocalizedError {
+    case accessDenied
     case failedReadingReminders
     case reminderHasNoDueDate
     
     var errorDescription: String? {
         switch self {
+        case .accessDenied:
+            return NSLocalizedString("The app doesn't have permission to read reminders.", comment: "access denied error description")
         case .failedReadingReminders:
             return NSLocalizedString("Failed to read reminders.", comment: "failed reading reminders error description")
         case .reminderHasNoDueDate:

--- a/Today/Models/TodayError.swift
+++ b/Today/Models/TodayError.swift
@@ -9,11 +9,14 @@ import Foundation
 
 enum TodayError: LocalizedError {
     case failedReadingReminders
+    case reminderHasNoDueDate
     
     var errorDescription: String? {
         switch self {
         case .failedReadingReminders:
             return NSLocalizedString("Failed to read reminders.", comment: "failed reading reminders error description")
+        case .reminderHasNoDueDate:
+            return NSLocalizedString("A reminder has no due date.", comment: "reminder has no due date error description")
         }
     }
 }

--- a/Today/Models/TodayError.swift
+++ b/Today/Models/TodayError.swift
@@ -1,0 +1,19 @@
+//
+//  TodayError.swift
+//  Today
+//
+//  Created by Sanghun Park on 08.09.22.
+//
+
+import Foundation
+
+enum TodayError: LocalizedError {
+    case failedReadingReminders
+    
+    var errorDescription: String? {
+        switch self {
+        case .failedReadingReminders:
+            return NSLocalizedString("Failed to read reminders.", comment: "failed reading reminders error description")
+        }
+    }
+}


### PR DESCRIPTION
Sync reminders between the app and EventKit as persisting data in an event store.

With the EventKit framework, the app can request access to a user’s calendar events and reminders. The app can use EventKit to share data between the Reminders and the app.

- Use Swift concurrency techniques to integrate with the EventKit API. 
- Create a reminder store abstraction that governs all communication between Reminders and the app.

- Update the app not to lose changes that the user made within the app, when app closes. 
- Update the app to automatically reflect changes the user makes outside of the app.
- Respond to change notifications from EventKit. 
- Save changes that a user makes in the app by writing those changes to their EventKit calendar.